### PR TITLE
rename deployment and namespace to align other capi project

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,12 +1,12 @@
 # Adds namespace to all resources.
-namespace: cluster-api-provider-proxmox-system
+namespace: cappx-system
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named
 # "wordpress" becomes "alices-wordpress".
 # Note that it should also match with the prefix (text before '-') of the namespace
 # field above.
-namePrefix: cluster-api-provider-proxmox-
+namePrefix: cappx-
 
 # Labels to add to all resources and selectors.
 #labels:


### PR DESCRIPTION
fix #121