### PR TITLE
add MachineHealthCheck 

### DIFF
--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -437,3 +437,24 @@ data:
           password: ${PROXMOX_PASSWORD:=""}
           tokenID: ${PROXMOX_TOKENID:=""}
           secret: ${PROXMOX_SECRET:=""}
+
+---
+
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: ${CLUSTER_NAME}-unhealthy-5m
+spec:
+  clusterName: '${CLUSTER_NAME}'
+  nodeStartupTimeout: 5m
+  maxUnhealthy: 100%
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/cluster-name: '${CLUSTER_NAME}'
+  unhealthyConditions:
+    - type: Ready
+      status: Unknown
+      timeout: 300s
+    - type: Ready
+      status: "False"
+      timeout: 300s


### PR DESCRIPTION
Hi @sp-yduck,

this adds a MachineHealthCheck for all Machines of a new cluster. This helps if the node does not go into a running state. E.g.  #145 or network problems during startup. 